### PR TITLE
ansible: add linting support

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,0 +1,12 @@
+PLAYBOOK := dotfiles.yml
+
+.PHONY: default
+default: run
+
+.PHONY: run
+run:
+	ansible-playbook --inventory='localhost,' --ask-become-pass "$(PLAYBOOK)"
+
+.PHONY: lint
+lint:
+	ansible-lint "$(PLAYBOOK)"

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,12 +1,27 @@
-PLAYBOOK := dotfiles.yml
+PLAYBOOK_CMD := ansible-playbook --inventory='localhost,' --ask-become-pass
+
+MAIN_PLAYBOOK := dotfiles.yml
+LINT_PLAYBOOK := lint.yml
 
 .PHONY: default
 default: run
 
 .PHONY: run
 run:
-	ansible-playbook --inventory='localhost,' --ask-become-pass "$(PLAYBOOK)"
+	$(PLAYBOOK_CMD) "$(MAIN_PLAYBOOK)"
 
 .PHONY: lint
 lint:
-	ansible-lint "$(PLAYBOOK)"
+	ansible-lint \
+	yaml-lint
+
+.PHONY: ansible-lint
+ansible-lint:
+	ansible-lint "$(MAIN_PLAYBOOK)" "$(LINT_PLAYBOOK)"
+
+YAML_FILES := $(shell git ls-files --exclude-standard --cached --others -- '*.yml')
+
+.PHONY: yaml-lint
+yaml-lint:
+	$(PLAYBOOK_CMD) "$(LINT_PLAYBOOK)"
+	prettier --format yaml --check $(YAML_FILES)

--- a/ansible/lint.yml
+++ b/ansible/lint.yml
@@ -1,0 +1,5 @@
+- hosts: [localhost]
+  connection: local
+  tasks:
+    - import_role:
+        name: prettier

--- a/ansible/roles/prettier/tasks/main.yml
+++ b/ansible/roles/prettier/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Install `prettier`
+  tags:
+    - prettier
+    - package
+  become: true
+  pacman:
+    name:
+      - prettier
+    state: present

--- a/ansible/roles/wallpaper/tasks/main.yml
+++ b/ansible/roles/wallpaper/tasks/main.yml
@@ -25,11 +25,13 @@
     state: link
 
 - name: Create mixin directories
-  import_tasks: ../common/tasks/create_mixin_dir.yml
+  tags:
+    - wallpaper
+    - filesystem
+    - .xprofile
+  import_tasks: "{{ playbook_dir }}/common/tasks/create_mixin_dir.yml"
   vars:
     mixin: ".xprofile"
-  tags:
-    - .xprofile
 
 - name: Deploy mixin script that sets wallpaper
   tags:

--- a/ansible/roles/wallpaper/tasks/main.yml
+++ b/ansible/roles/wallpaper/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Create wallpapers directory
   tags:
-    - wallpapers
+    - wallpaper
     - filesystem
   file:
     dest: "{{ wallpapers_dir }}"
@@ -8,7 +8,7 @@
 
 - name: Download wallpapers
   tags:
-    - wallpapers
+    - wallpaper
     - fetch
   loop: "{{ wallpapers }}"
   get_url:

--- a/ansible/roles/wallpaper/vars/main.yml
+++ b/ansible/roles/wallpaper/vars/main.yml
@@ -1,8 +1,20 @@
 wallpapers_dir: "{{ ansible_env.HOME }}/wallpapers"
 wallpapers:
-  - { name: "summer-night-beach.jpg", url: "https://unsplash.com/photos/wwBk0aCa7Gs/download?force=true" }
-  - { name: "forest.jpg",             url: "https://unsplash.com/photos/sp-p7uuT0tw/download?force=true" }
-  - { name: "milky-way.jpg",          url: "https://unsplash.com/photos/zepnJQycr4U/download?force=true" }
-  - { name: "wood-panels.jpg",        url: "https://unsplash.com/photos/7JZPXJRu7jU/download?force=true" }
+  - {
+      name: "summer-night-beach.jpg",
+      url: "https://unsplash.com/photos/wwBk0aCa7Gs/download?force=true",
+    }
+  - {
+      name: "forest.jpg",
+      url: "https://unsplash.com/photos/sp-p7uuT0tw/download?force=true",
+    }
+  - {
+      name: "milky-way.jpg",
+      url: "https://unsplash.com/photos/zepnJQycr4U/download?force=true",
+    }
+  - {
+      name: "wood-panels.jpg",
+      url: "https://unsplash.com/photos/7JZPXJRu7jU/download?force=true",
+    }
 current_wallpaper_name: milky-way.jpg
 current_wallpaper_link: "{{ config_dir }}/wallpaper"


### PR DESCRIPTION
This PR adds a `Makefile`, along with a new playbook, that allows for installation of `prettier` which is then used for linting YAML files. This could be a first step towards having some kind of CI for this repository.