### PR TITLE
ansible: fix bug in `lint` target

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -11,7 +11,7 @@ run:
 	$(PLAYBOOK_CMD) "$(MAIN_PLAYBOOK)"
 
 .PHONY: lint
-lint:
+lint: \
 	ansible-lint \
 	yaml-lint
 


### PR DESCRIPTION
The backslash is needed so that `make` interprets the list as the
dependencies, and not as commands to issue.