### PR TITLE
Use locally installed version of `prettier`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "base16-zathura"]
 	path = user-config/zathura/.config/zathura/base16-zathura
 	url = https://github.com/nicodebo/base16-zathura
+[submodule "ansible/tools/prettier"]
+	path = ansible/tools/prettier
+	url = https://github.com/Saser/mk-prettier

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -23,3 +23,7 @@ YAML_FILES := $(shell git ls-files --exclude-standard --cached --others -- '*.ym
 .PHONY: yaml-lint
 yaml-lint: $(PRETTIER)
 	$(PRETTIER) --check $(YAML_FILES)
+
+.PHONY: yaml-format
+yaml-format: $(PRETTIER)
+	$(PRETTIER) --write $(YAML_FILES)

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,14 +1,13 @@
-PLAYBOOK_CMD := ansible-playbook --inventory='localhost,' --ask-become-pass
-
-MAIN_PLAYBOOK := dotfiles.yml
-LINT_PLAYBOOK := lint.yml
+PLAYBOOK := dotfiles.yml
 
 .PHONY: default
 default: run
 
+include tools/prettier/Makefile
+
 .PHONY: run
 run:
-	$(PLAYBOOK_CMD) "$(MAIN_PLAYBOOK)"
+	ansible-playbook --inventory='localhost,' --ask-become-pass '$(PLAYBOOK)'
 
 .PHONY: lint
 lint: \
@@ -17,11 +16,10 @@ lint: \
 
 .PHONY: ansible-lint
 ansible-lint:
-	ansible-lint "$(MAIN_PLAYBOOK)" "$(LINT_PLAYBOOK)"
+	ansible-lint '$(PLAYBOOK)'
 
 YAML_FILES := $(shell git ls-files --exclude-standard --cached --others -- '*.yml')
 
 .PHONY: yaml-lint
-yaml-lint:
-	$(PLAYBOOK_CMD) "$(LINT_PLAYBOOK)"
-	prettier --check $(YAML_FILES)
+yaml-lint: $(PRETTIER)
+	$(PRETTIER) --check $(YAML_FILES)

--- a/ansible/lint.yml
+++ b/ansible/lint.yml
@@ -1,5 +1,0 @@
-- hosts: [localhost]
-  connection: local
-  tasks:
-    - import_role:
-        name: prettier

--- a/ansible/roles/prettier/tasks/main.yml
+++ b/ansible/roles/prettier/tasks/main.yml
@@ -1,9 +1,0 @@
-- name: Install `prettier`
-  tags:
-    - prettier
-    - package
-  become: true
-  pacman:
-    name:
-      - prettier
-    state: present


### PR DESCRIPTION
Using a separate Ansible playbook was a bad idea.
* It pollutes the global environment with a globally installed version of `prettier`.
* It pollutes the `roles` directory by adding a role that is only needed for linting.
* It pollutes the overall feel of the Ansible-based configuration by having another playbook.