### PR TITLE
ansible/xorg: explicitly state what packages should be installed

### DIFF
--- a/ansible/roles/xorg/tasks/main.yml
+++ b/ansible/roles/xorg/tasks/main.yml
@@ -1,3 +1,18 @@
+- name: Install X server and related packages
+  tags:
+    - xorg
+    - package
+  become: true
+  pacman:
+    name:
+      - xclip
+      - xf86-video-intel
+      - xorg-server
+      - xorg-xbacklight
+      - xorg-xinit
+      - xorg-xrdb
+    state: present
+
 - name: Deploy `.xprofile`
   tags:
     - xorg


### PR DESCRIPTION
It is unclear whether packages such as `xclip` should be listed here, as they are not strictly necessary for the `xorg` role. Instead, `xclip` is used in configurations such as `emacs` and `tmux`. For now, I'll leave it in here, and perhaps duplicating/moving it later.